### PR TITLE
MTDSA-7055 Dependency Upgrade Test Branch

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,23 +22,23 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc"   %% "bootstrap-play-26" % "1.5.0",
-    "uk.gov.hmrc"   %% "domain"            % "5.6.0-play-26",
+    "uk.gov.hmrc"   %% "bootstrap-play-26" % "1.15.0",
+    "uk.gov.hmrc"   %% "domain"            % "5.9.0-play-26",
     "uk.gov.hmrc"   %% "play-hmrc-api"     % "4.1.0-play-26",
-    "org.typelevel" %% "cats-core"         % "2.1.0",
-    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.4.4" cross CrossVersion.full),
-    "com.github.ghik" % "silencer-lib" % "1.4.4" % Provided cross CrossVersion.full,
-    "com.chuusai"   %% "shapeless"         % "2.3.3"
+    "org.typelevel" %% "cats-core"         % "2.2.0",
+    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
+    "com.github.ghik" % "silencer-lib" % "1.6.0" % Provided cross CrossVersion.full,
+    "com.chuusai"   %% "shapeless"         % "2.4.0-M1"
   )
 
   def test(scope: String = "test, it"): Seq[sbt.ModuleID] = Seq(
-    "org.scalatest"          %% "scalatest"          % "3.1.0"             % scope,
+    "org.scalatest"          %% "scalatest"          % "3.2.0"             % scope,
     "com.vladsch.flexmark"   % "flexmark-all"        % "0.35.10"           % scope,
     "org.scalacheck"         %% "scalacheck"         % "1.14.2"            % scope,
-    "org.scalamock"          %% "scalamock"          % "4.4.0"             % scope,
+    "org.scalamock"          %% "scalamock"          % "5.0.0"             % scope,
     "com.typesafe.play"      %% "play-test"          % PlayVersion.current % scope,
     "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2"             % scope,
-    "com.github.tomakehurst" % "wiremock"            % "2.25.1"            % scope
+    "com.github.tomakehurst" % "wiremock"            % "2.27.2"            % scope
   )
 
   // Fixes a transitive dependency clash between wiremock and scalatestplus-play

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.7
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,11 +18,11 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.5.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 

--- a/test/utils/ErrorHandlerSpec.scala
+++ b/test/utils/ErrorHandlerSpec.scala
@@ -16,7 +16,7 @@
 
 package utils
 
-import org.joda.time.DateTime
+import java.time.Instant
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
 import play.api.http.Status
@@ -58,7 +58,7 @@ class ErrorHandlerSpec extends UnitSpec with GuiceOneAppPerSuite {
       eventId = "",
       tags = eventTags,
       detail = Map("test" -> "test"),
-      generatedAt = DateTime.now()
+      generatedAt = Instant.now()
     )
 
     (httpAuditEvent.dataEvent(_: String, _: String, _: RequestHeader, _: Map[String, String])(_: HeaderCarrier)).expects(*, *, *, *, *)


### PR DESCRIPTION
Many Dependencies can be upgraded:

sbt 1.3.7 -> 1.3.13

ScalaTest 3.1.0 -> 3.2.0

scalamock 4.4.0 -> 5.0.0
domain 5.6.0 -> 5.9.0

cats-core 2.1.0 -> 2.2.0

silencer-plugin 1.4.4 -> 1.6.0

silencer-lib 1.4.4 -> 1.6.0

shapeless 2.3.3 > 2.4.0-M1

wiremock 2.25.1 -> 2.27.2

sbt-auto-build 2.6.0 -> 2.10.0

sbt-artifactory 1.2.0 -> 1.5.0

 

bootstrap-play.26 can be done but it requires replacing Joda.Time with Java.time.instant

 

Scala > 2.13 doesn't seem feasible as half of the dependencies are ready for it yet.

Flexmark and scalatestplus-play create a bunch of issues when initially tried. Not that they can't be resolved it's just not super simple

 