### PR TITLE
MTDSA-31515 Fix Create and Amend Charitable Giving to avoid sending null values downstream in V1, V2 and V3

### DIFF
--- a/app/v1/createAndAmendCharitableGivingReliefs/def1/model/request/Def1_GiftAidPayments.scala
+++ b/app/v1/createAndAmendCharitableGivingReliefs/def1/model/request/Def1_GiftAidPayments.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package v1.createAndAmendCharitableGivingReliefs.def1.model.request
 
-import play.api.libs.json.{JsObject, Json, Reads, Writes}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
 
 case class Def1_GiftAidPayments(nonUkCharities: Option[Def1_NonUkCharities],
                                 totalAmount: Option[BigDecimal],
@@ -28,17 +29,21 @@ object Def1_GiftAidPayments {
 
   implicit val reads: Reads[Def1_GiftAidPayments] = Json.reads[Def1_GiftAidPayments]
 
-  implicit val writes: Writes[Def1_GiftAidPayments] = new Writes[Def1_GiftAidPayments] {
-
-    def writes(o: Def1_GiftAidPayments): JsObject = Json.obj(
-      "nonUkCharitiesCharityNames"       -> o.nonUkCharities.map(_.charityNames),
-      "nonUkCharities"                   -> o.nonUkCharities.map(_.totalAmount),
-      "currentYear"                      -> o.totalAmount,
-      "oneOffCurrentYear"                -> o.oneOffAmount,
-      "currentYearTreatedAsPreviousYear" -> o.amountTreatedAsPreviousTaxYear,
-      "nextYearTreatedAsCurrentYear"     -> o.amountTreatedAsSpecifiedTaxYear
-    )
-
-  }
+  implicit val writes: OWrites[Def1_GiftAidPayments] = (
+    (JsPath \ "nonUkCharitiesCharityNames").writeNullable[Seq[String]] and
+      (JsPath \ "nonUkCharities").writeNullable[BigDecimal] and
+      (JsPath \ "currentYear").writeNullable[BigDecimal] and
+      (JsPath \ "oneOffCurrentYear").writeNullable[BigDecimal] and
+      (JsPath \ "currentYearTreatedAsPreviousYear").writeNullable[BigDecimal] and
+      (JsPath \ "nextYearTreatedAsCurrentYear").writeNullable[BigDecimal]
+  )(giftAidPayments =>
+    (
+      giftAidPayments.nonUkCharities.flatMap(_.charityNames),
+      giftAidPayments.nonUkCharities.map(_.totalAmount),
+      giftAidPayments.totalAmount,
+      giftAidPayments.oneOffAmount,
+      giftAidPayments.amountTreatedAsPreviousTaxYear,
+      giftAidPayments.amountTreatedAsSpecifiedTaxYear
+    ))
 
 }

--- a/app/v1/createAndAmendCharitableGivingReliefs/def1/model/request/Def1_Gifts.scala
+++ b/app/v1/createAndAmendCharitableGivingReliefs/def1/model/request/Def1_Gifts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package v1.createAndAmendCharitableGivingReliefs.def1.model.request
 
-import play.api.libs.json.{JsObject, Json, Reads, Writes}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
 
 case class Def1_Gifts(nonUkCharities: Option[Def1_NonUkCharities], landAndBuildings: Option[BigDecimal], sharesOrSecurities: Option[BigDecimal])
 
@@ -24,15 +25,17 @@ object Def1_Gifts {
 
   implicit val reads: Reads[Def1_Gifts] = Json.reads[Def1_Gifts]
 
-  implicit val writes: Writes[Def1_Gifts] = new Writes[Def1_Gifts] {
-
-    def writes(o: Def1_Gifts): JsObject = Json.obj(
-      "investmentsNonUkCharitiesCharityNames" -> o.nonUkCharities.map(_.charityNames),
-      "investmentsNonUkCharities"             -> o.nonUkCharities.map(_.totalAmount),
-      "landAndBuildings"                      -> o.landAndBuildings,
-      "sharesOrSecurities"                    -> o.sharesOrSecurities
-    )
-
-  }
+  implicit val writes: OWrites[Def1_Gifts] = (
+    (JsPath \ "investmentsNonUkCharitiesCharityNames").writeNullable[Seq[String]] and
+      (JsPath \ "investmentsNonUkCharities").writeNullable[BigDecimal] and
+      (JsPath \ "landAndBuildings").writeNullable[BigDecimal] and
+      (JsPath \ "sharesOrSecurities").writeNullable[BigDecimal]
+  )(gifts =>
+    (
+      gifts.nonUkCharities.flatMap(_.charityNames),
+      gifts.nonUkCharities.map(_.totalAmount),
+      gifts.landAndBuildings,
+      gifts.sharesOrSecurities
+    ))
 
 }

--- a/app/v2/charitableGiving/createAmend/def1/model/request/Def1_GiftAidPayments.scala
+++ b/app/v2/charitableGiving/createAmend/def1/model/request/Def1_GiftAidPayments.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package v2.charitableGiving.createAmend.def1.model.request
 
-import play.api.libs.json.{JsObject, Json, Reads, Writes}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
 
 case class Def1_GiftAidPayments(nonUkCharities: Option[Def1_NonUkCharities],
                                 totalAmount: Option[BigDecimal],
@@ -28,17 +29,21 @@ object Def1_GiftAidPayments {
 
   implicit val reads: Reads[Def1_GiftAidPayments] = Json.reads[Def1_GiftAidPayments]
 
-  implicit val writes: Writes[Def1_GiftAidPayments] = new Writes[Def1_GiftAidPayments] {
-
-    def writes(o: Def1_GiftAidPayments): JsObject = Json.obj(
-      "nonUkCharitiesCharityNames"       -> o.nonUkCharities.map(_.charityNames),
-      "nonUkCharities"                   -> o.nonUkCharities.map(_.totalAmount),
-      "currentYear"                      -> o.totalAmount,
-      "oneOffCurrentYear"                -> o.oneOffAmount,
-      "currentYearTreatedAsPreviousYear" -> o.amountTreatedAsPreviousTaxYear,
-      "nextYearTreatedAsCurrentYear"     -> o.amountTreatedAsSpecifiedTaxYear
-    )
-
-  }
+  implicit val writes: OWrites[Def1_GiftAidPayments] = (
+    (JsPath \ "nonUkCharitiesCharityNames").writeNullable[Seq[String]] and
+      (JsPath \ "nonUkCharities").writeNullable[BigDecimal] and
+      (JsPath \ "currentYear").writeNullable[BigDecimal] and
+      (JsPath \ "oneOffCurrentYear").writeNullable[BigDecimal] and
+      (JsPath \ "currentYearTreatedAsPreviousYear").writeNullable[BigDecimal] and
+      (JsPath \ "nextYearTreatedAsCurrentYear").writeNullable[BigDecimal]
+  )(giftAidPayments =>
+    (
+      giftAidPayments.nonUkCharities.flatMap(_.charityNames),
+      giftAidPayments.nonUkCharities.map(_.totalAmount),
+      giftAidPayments.totalAmount,
+      giftAidPayments.oneOffAmount,
+      giftAidPayments.amountTreatedAsPreviousTaxYear,
+      giftAidPayments.amountTreatedAsSpecifiedTaxYear
+    ))
 
 }

--- a/app/v2/charitableGiving/createAmend/def1/model/request/Def1_Gifts.scala
+++ b/app/v2/charitableGiving/createAmend/def1/model/request/Def1_Gifts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package v2.charitableGiving.createAmend.def1.model.request
 
-import play.api.libs.json.{JsObject, Json, Reads, Writes}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
 
 case class Def1_Gifts(nonUkCharities: Option[Def1_NonUkCharities], landAndBuildings: Option[BigDecimal], sharesOrSecurities: Option[BigDecimal])
 
@@ -24,15 +25,17 @@ object Def1_Gifts {
 
   implicit val reads: Reads[Def1_Gifts] = Json.reads[Def1_Gifts]
 
-  implicit val writes: Writes[Def1_Gifts] = new Writes[Def1_Gifts] {
-
-    def writes(o: Def1_Gifts): JsObject = Json.obj(
-      "investmentsNonUkCharitiesCharityNames" -> o.nonUkCharities.map(_.charityNames),
-      "investmentsNonUkCharities"             -> o.nonUkCharities.map(_.totalAmount),
-      "landAndBuildings"                      -> o.landAndBuildings,
-      "sharesOrSecurities"                    -> o.sharesOrSecurities
-    )
-
-  }
+  implicit val writes: OWrites[Def1_Gifts] = (
+    (JsPath \ "investmentsNonUkCharitiesCharityNames").writeNullable[Seq[String]] and
+      (JsPath \ "investmentsNonUkCharities").writeNullable[BigDecimal] and
+      (JsPath \ "landAndBuildings").writeNullable[BigDecimal] and
+      (JsPath \ "sharesOrSecurities").writeNullable[BigDecimal]
+  )(gifts =>
+    (
+      gifts.nonUkCharities.flatMap(_.charityNames),
+      gifts.nonUkCharities.map(_.totalAmount),
+      gifts.landAndBuildings,
+      gifts.sharesOrSecurities
+    ))
 
 }

--- a/app/v3/charitableGiving/createAmend/def1/model/request/Def1_GiftAidPayments.scala
+++ b/app/v3/charitableGiving/createAmend/def1/model/request/Def1_GiftAidPayments.scala
@@ -16,7 +16,8 @@
 
 package v3.charitableGiving.createAmend.def1.model.request
 
-import play.api.libs.json.{JsObject, Json, Reads, Writes}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
 
 case class Def1_GiftAidPayments(nonUkCharities: Option[Def1_NonUkCharities],
                                 totalAmount: Option[BigDecimal],
@@ -28,17 +29,21 @@ object Def1_GiftAidPayments {
 
   implicit val reads: Reads[Def1_GiftAidPayments] = Json.reads[Def1_GiftAidPayments]
 
-  implicit val writes: Writes[Def1_GiftAidPayments] = new Writes[Def1_GiftAidPayments] {
-
-    def writes(o: Def1_GiftAidPayments): JsObject = Json.obj(
-      "nonUkCharitiesCharityNames"       -> o.nonUkCharities.map(_.charityNames),
-      "nonUkCharities"                   -> o.nonUkCharities.map(_.totalAmount),
-      "currentYear"                      -> o.totalAmount,
-      "oneOffCurrentYear"                -> o.oneOffAmount,
-      "currentYearTreatedAsPreviousYear" -> o.amountTreatedAsPreviousTaxYear,
-      "nextYearTreatedAsCurrentYear"     -> o.amountTreatedAsSpecifiedTaxYear
-    )
-
-  }
+  implicit val writes: OWrites[Def1_GiftAidPayments] = (
+    (JsPath \ "nonUkCharitiesCharityNames").writeNullable[Seq[String]] and
+      (JsPath \ "nonUkCharities").writeNullable[BigDecimal] and
+      (JsPath \ "currentYear").writeNullable[BigDecimal] and
+      (JsPath \ "oneOffCurrentYear").writeNullable[BigDecimal] and
+      (JsPath \ "currentYearTreatedAsPreviousYear").writeNullable[BigDecimal] and
+      (JsPath \ "nextYearTreatedAsCurrentYear").writeNullable[BigDecimal]
+  )(giftAidPayments =>
+    (
+      giftAidPayments.nonUkCharities.flatMap(_.charityNames),
+      giftAidPayments.nonUkCharities.map(_.totalAmount),
+      giftAidPayments.totalAmount,
+      giftAidPayments.oneOffAmount,
+      giftAidPayments.amountTreatedAsPreviousTaxYear,
+      giftAidPayments.amountTreatedAsSpecifiedTaxYear
+    ))
 
 }

--- a/app/v3/charitableGiving/createAmend/def1/model/request/Def1_Gifts.scala
+++ b/app/v3/charitableGiving/createAmend/def1/model/request/Def1_Gifts.scala
@@ -16,7 +16,8 @@
 
 package v3.charitableGiving.createAmend.def1.model.request
 
-import play.api.libs.json.{JsObject, Json, Reads, Writes}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
 
 case class Def1_Gifts(nonUkCharities: Option[Def1_NonUkCharities], landAndBuildings: Option[BigDecimal], sharesOrSecurities: Option[BigDecimal])
 
@@ -24,15 +25,17 @@ object Def1_Gifts {
 
   implicit val reads: Reads[Def1_Gifts] = Json.reads[Def1_Gifts]
 
-  implicit val writes: Writes[Def1_Gifts] = new Writes[Def1_Gifts] {
-
-    def writes(o: Def1_Gifts): JsObject = Json.obj(
-      "investmentsNonUkCharitiesCharityNames" -> o.nonUkCharities.map(_.charityNames),
-      "investmentsNonUkCharities"             -> o.nonUkCharities.map(_.totalAmount),
-      "landAndBuildings"                      -> o.landAndBuildings,
-      "sharesOrSecurities"                    -> o.sharesOrSecurities
-    )
-
-  }
+  implicit val writes: OWrites[Def1_Gifts] = (
+    (JsPath \ "investmentsNonUkCharitiesCharityNames").writeNullable[Seq[String]] and
+      (JsPath \ "investmentsNonUkCharities").writeNullable[BigDecimal] and
+      (JsPath \ "landAndBuildings").writeNullable[BigDecimal] and
+      (JsPath \ "sharesOrSecurities").writeNullable[BigDecimal]
+  )(gifts =>
+    (
+      gifts.nonUkCharities.flatMap(_.charityNames),
+      gifts.nonUkCharities.map(_.totalAmount),
+      gifts.landAndBuildings,
+      gifts.sharesOrSecurities
+    ))
 
 }


### PR DESCRIPTION
Chose `OWrites` with `writeNullable` since it’s more idiomatic than relying on the custom `filterNull` helper.

Request Body with null values (Before)
<img width="1703" height="73" alt="Before" src="https://github.com/user-attachments/assets/1fd2fb14-3dc6-4d4d-bce7-9a683595afa7" />

Request Body without null values (After)
<img width="1709" height="65" alt="After" src="https://github.com/user-attachments/assets/fd14d81a-f9ba-4899-a370-2bc28012ddab" />

